### PR TITLE
Add some tags from Create to some items and blocks

### DIFF
--- a/src/main/resources/data/create/tags/blocks/wrench_pickup.json
+++ b/src/main/resources/data/create/tags/blocks/wrench_pickup.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "shelve:channeler",
+    "shelve:igniter",
+    "shelve:harvester",
+    "shelve:humidity_detector",
+    "shelve:static_detector",
+    "shelve:bear_trap"
+  ]
+}

--- a/src/main/resources/data/create/tags/items/upright_on_belt.json
+++ b/src/main/resources/data/create/tags/items/upright_on_belt.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "shelve:cheese_cake"
+  ]
+}


### PR DESCRIPTION
Added the tag `create:wrench_pickup` to `shelve:channeler`, `shelve:igniter`, `shelve:harvester`, `shelve:humidity_detector`, `shelve:static_detector` and `shelve:bear_trap`.
Added the tag `create:upright_on_belt` to `shelve:cheese_cake`.