### PR TITLE
Add a tag from Create to new blocks

### DIFF
--- a/src/main/resources/data/create/tags/blocks/wrench_pickup.json
+++ b/src/main/resources/data/create/tags/blocks/wrench_pickup.json
@@ -8,6 +8,8 @@
     "shelve:static_detector",
     "shelve:resonator",
     "shelve:rheostat",
-    "shelve:bear_trap"
+    "shelve:bear_trap",
+    "shelve:bar_charger",
+    "shelve:frame_thrower"
   ]
 } 


### PR DESCRIPTION
Added the tag `create:wrench_pickup` to `shelve:bar_charger`, `shelve:flame_thrower`.